### PR TITLE
Travis notif color

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_script:
 notifications:
   irc:
     channels:
-      - "irc.mozilla.org#releng"
+      - "irc.mozilla.org#callek"
     on_success: always
     on_failure: always
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ notifications:
     on_success: always
     on_failure: always
     template:
-      - "\x02%{repository}\x02#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
-      - "\x02Change view\x02 : %{compare_url}"
-      - "\x02Build details\x02 : %{build_url}"
-      - "\x02Commit message\x02 : %{commit_message}"
+      - "\x02%{repository}#%{build_number}\x02 (%{branch} - %{commit} : %{author}): \x02\x0312%{message}\x02\x03"
+      - "\x02Change view\x02 : \x0314%{compare_url}\x03"
+      - "\x02Build details\x02 : \x0314%{build_url}\x03"
+      - "\x02Commit message\x02 : \x0314%{commit_message}\x03"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ notifications:
     on_success: always
     on_failure: always
     template:
-      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
-      - "Change view : %{compare_url}"
-      - "Build details : %{build_url}"
-      - "Commit message : %{commit_message}"
+      - "\x02%{repository}\x02#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+      - "\x02Change view\x02 : %{compare_url}"
+      - "\x02Build details\x02 : %{build_url}"
+      - "\x02Commit message\x02 : %{commit_message}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ after_script:
 notifications:
   irc:
     channels:
-      - "irc.mozilla.org#callek"
+      - "irc.mozilla.org#releng"
     on_success: always
     on_failure: always
     template:
-      - "\x02%{repository}#%{build_number}\x02 (%{branch} - %{commit} : %{author}): \x02\x0312%{message}\x02\x03"
+      - "\x02%{repository}\x0314#%{build_number}\x03\x02 (%{branch} - %{commit} : %{author}): \x02\x0312%{message}\x02\x03"
       - "\x02Change view\x02 : \x0314%{compare_url}\x03"
       - "\x02Build details\x02 : \x0314%{build_url}\x03"
       - "\x02Commit message\x02 : \x0314%{commit_message}\x03"


### PR DESCRIPTION
This adds color to the travis notification, if this is popular I'll adjust other travis notifications we have.

This does the following: 
* All "header" entries (start of line) are bolded
* The Build Number is de-emphasized (currently in chatzilla it links to a channel, here I color it grey)
* The success/failure message is colored (though due to a travis limitation, is not colored red/green, so to avoid confusion on glancing I chose blue, so it stands out but doesn't evoke pass-fail mentality)
* All urls are grey to try and avoid them disrupting skim-flow of IRC conversation
* Checkin Comment is also grey.